### PR TITLE
FDS-652 use 'file_only' manifest type

### DIFF
--- a/R/manifest.R
+++ b/R/manifest.R
@@ -317,7 +317,7 @@ update_data_flow_manifest <- function(asset_view,
                    file_name = file_path,
                    restrict_rules = TRUE,
                    access_token = access_token,
-                   manifest_record_type = "table_and_file",
+                   manifest_record_type = "file_only",
                    base_url = base_url,
                    schema_url = schema_url)
   } else {

--- a/R/mod_submit_model.R
+++ b/R/mod_submit_model.R
@@ -61,7 +61,7 @@ mod_submit_model_server <- function(id,
                    file_name = path,
                    restrict_rules = TRUE,
                    access_token = access_token,
-                   manifest_record_type = "table_and_file",
+                   manifest_record_type = "file_only",
                    schema_url = schema_url,
                    base_url = base_url)
 

--- a/R/schematic_rest_api.R
+++ b/R/schematic_rest_api.R
@@ -86,7 +86,7 @@ model_submit <- function(data_type = NULL,
                          file_name,
                          access_token,
                          restrict_rules = TRUE,
-                         manifest_record_type = "table_and_file",
+                         manifest_record_type = "file_only",
                          base_url = "https://schematic-dev.api.sagebionetworks.org",
                          schema_url="https://raw.githubusercontent.com/Sage-Bionetworks/data_flow/main/inst/data_flow_component.jsonld",
                          use_schema_label = TRUE) {


### PR DESCRIPTION
Switch `manifest_record_type` from `table_and_file` to `file_only`.

Lingling suggested this fix due to hang up with [HTAN DataFlow model submission](https://sagebionetworks.jira.com/browse/FDS-604).