### PR TITLE
Fds 882 Fix dashboard column display names

### DIFF
--- a/R/datatable_functions.R
+++ b/R/datatable_functions.R
@@ -61,6 +61,17 @@ style_dashboard <- function(prepped_manifest,
 
   defs <- append(defs, na_replace_defs)
 
+  ## RENAME COLUMN NAMES  ######################################################
+  # get column names for datatable display
+  # FIXME: Not sure why using colnames parameter in DT::datatable broke
+  colnames <- purrr::map(config, "display_name")
+
+  # if colnames isn't null, arrange in order of dataframe
+  if (!is.null(colnames)) {
+    display_colnames <- as.character(ifelse(is.na(colnames), names(colnames), colnames))
+    names(prepped_manifest) <- display_colnames
+  }
+
   ## CREATE DATA TABLE   #######################################################
   dt <- DT::datatable(prepped_manifest,
                       escape = FALSE,
@@ -99,17 +110,6 @@ prep_manifest_dash <- function(df,
   expected_colnames <- names(config)
 
   df <- rearrange_dataframe(df, expected_colnames)
-
-  ## RENAME COLUMN NAMES  ######################################################
-  # get column names for datatable display
-  # FIXME: Not sure why using colnames parameter in DT::datatable broke
-  colnames <- purrr::map(config, "display_name")
-
-  # if colnames isn't null, arrange in order of dataframe
-  if (!is.null(colnames)) {
-    display_colnames <- as.character(ifelse(is.na(colnames), names(colnames), colnames))
-    names(df) <- display_colnames
-  }
 
   return(df)
 }

--- a/R/datatable_functions.R
+++ b/R/datatable_functions.R
@@ -100,8 +100,9 @@ prep_manifest_dash <- function(df,
 
   df <- rearrange_dataframe(df, expected_colnames)
 
-  ## CREATE COLUMN NAMES  ######################################################
+  ## RENAME COLUMN NAMES  ######################################################
   # get column names for datatable display
+  # FIXME: Not sure why using colnames parameter in DT::datatable broke
   colnames <- purrr::map(config, "display_name")
 
   # if colnames isn't null, arrange in order of dataframe

--- a/R/datatable_functions.R
+++ b/R/datatable_functions.R
@@ -61,19 +61,11 @@ style_dashboard <- function(prepped_manifest,
 
   defs <- append(defs, na_replace_defs)
 
-  ## CREATE COLUMN NAMES  ######################################################
-  # get column names for datatable display
-  colnames <- get_renamed_colnames(config)
-
-  # put empty string in front to account for rownum column
-  colnames <- c("", colnames)
-
   ## CREATE DATA TABLE   #######################################################
   dt <- DT::datatable(prepped_manifest,
                       escape = FALSE,
                       selection = "none",
                       filter = "none",
-                      colnames = colnames,
                       options = list(scrollX = TRUE,
                                      scrollY = 500,
                                      bPaginate = FALSE,
@@ -107,6 +99,16 @@ prep_manifest_dash <- function(df,
   expected_colnames <- names(config)
 
   df <- rearrange_dataframe(df, expected_colnames)
+
+  ## CREATE COLUMN NAMES  ######################################################
+  # get column names for datatable display
+  colnames <- purrr::map(config, "display_name")
+
+  # if colnames isn't null, arrange in order of dataframe
+  if (!is.null(colnames)) {
+    display_colnames <- as.character(ifelse(is.na(colnames), names(colnames), colnames))
+    names(df) <- display_colnames
+  }
 
   return(df)
 }

--- a/R/manifest.R
+++ b/R/manifest.R
@@ -11,11 +11,6 @@ prep_manifest_dfa <- function(manifest,
   # convert "Not Applicable" to NA
   manifest[ manifest == "Not Applicable" ] <- NA
 
-  # convert contribute and dataset to factor
-  # manifest <- convert_column_type(df = manifest,
-  #                                 col_names = get_colname_by_type("drop_down_filter", config),
-  #                                 type = "factor")
-
   # num_items to integer column
   manifest <- convert_column_type(df = manifest,
                                   col_names = get_colname_by_type("int", config),


### PR DESCRIPTION
For some reason `colname` parameter in `DT::datatable` broke. I wasn't able to diagnose a cause and fix so I rename the manifest column names outside of the `DT::datatable` function