### PR TITLE
Run tests using dev/staging/prod schematic api

### DIFF
--- a/.github/workflows/devtools_tests.yml
+++ b/.github/workflows/devtools_tests.yml
@@ -13,7 +13,9 @@ jobs:
     
     env:
       SYNAPSE_PAT: ${{ secrets.SYNAPSE_PAT }}
-      SCHEMATIC_BASE_URL_AWS: ${{ secrets.SCHEMATIC_BASE_URL_AWS }}
+      SCHEMATIC_URL_DEV: https://schematic-dev.api.sagebionetworks.org
+      SCHEMATIC_URL_STAGING: https://schematic-staging.api.sagebionetworks.org
+      SCHEMATIC_URL_PROD: https://schematic.api.sagebionetworks.org
 
     steps:
       - uses: actions/checkout@v3
@@ -25,6 +27,23 @@ jobs:
         run: |
           install.packages(c("remotes", "rcmdcheck", "devtools"))
           remotes::install_deps(dependencies = TRUE)
+        shell: Rscript {0}
+      - name: Add schematic base URL to Renviron
+        run: |
+    
+          refName <- Sys.getenv("GITHUB_REF_NAME")
+          
+          if (grepl("v[0-9]+.[0-9]+.[0-9]+", refName)) {
+            message("Testing using production schematic API instance")
+            renviron <- "DFA_SCHEMATIC_API_URL = '${{ env.SCHEMATIC_URL_PROD }}'"
+            } else if (refName == "main") {
+              renviron <- "DFA_SCHEMATIC_API_URL = '${{ env.SCHEMATIC_URL_STAGING }}'"
+              message("Testing using staging schematic API instance")
+          } else {
+            appName <- paste(appName, "testing", sep = "-")
+            renviron <- "DFA_SCHEMATIC_API_URL = '${{ env.SCHEMATIC_URL_DEV }}'"
+            message("Testing using dev schematic API instance")
+          }
         shell: Rscript {0}
       - name: Check
         run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "error")

--- a/.github/workflows/devtools_tests.yml
+++ b/.github/workflows/devtools_tests.yml
@@ -40,7 +40,6 @@ jobs:
               renviron <- "DFA_SCHEMATIC_API_URL = '${{ env.SCHEMATIC_URL_STAGING }}'"
               message("Testing using staging schematic API instance")
           } else {
-            appName <- paste(appName, "testing", sep = "-")
             renviron <- "DFA_SCHEMATIC_API_URL = '${{ env.SCHEMATIC_URL_DEV }}'"
             message("Testing using dev schematic API instance")
           }

--- a/.github/workflows/devtools_tests.yml
+++ b/.github/workflows/devtools_tests.yml
@@ -43,6 +43,10 @@ jobs:
             renviron <- "DFA_SCHEMATIC_API_URL = '${{ env.SCHEMATIC_URL_DEV }}'"
             message("Testing using dev schematic API instance")
           }
+
+          # write .Renviron
+          writeLines(renviron, ".Renviron") 
+          
         shell: Rscript {0}
       - name: Check
         run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "error")

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,8 @@ repos:
     # -   id: codemeta-description-updated
     -   id: use-tidy-description
     -   id: lintr
+        args: [--warn_only]
+        verbose: true
     -   id: readme-rmd-rendered
     -   id: parsable-R
     -   id: no-browser-statement

--- a/R/schematic_rest_api.R
+++ b/R/schematic_rest_api.R
@@ -25,14 +25,8 @@ dataset_manifest_download <- function(asset_view,
   # create api url
   url <- paste0(base_url, "/v1/dataset/manifest/download")
 
-  # set up header w token
-  headers <- c(
-    `access_token` = access_token
-  )
-
   # set up parameters for httr::get call
   params <- list(
-    `access_token` = access_token,
     `asset_view` = asset_view,
     `dataset_id` = dataset_id,
     `as_json` = TRUE,
@@ -40,7 +34,11 @@ dataset_manifest_download <- function(asset_view,
   )
 
   # run GET
-  res <- httr::GET(url = url, query = params)
+  res <- httr::GET(
+    url = url,
+    httr::add_headers(Authorization = sprintf("Bearer %s", access_token)),
+    query = params
+  )
 
   # pull out content from request
   parsed <- suppressMessages(
@@ -106,11 +104,6 @@ model_submit <- function(data_type = NULL,
   # create url
   url <- paste0(base_url, "/v1/model/submit")
 
-  # set up header w token
-  headers <- c(
-    `access_token` = access_token
-  )
-
   # set up parameters for httr::get call
   params <- list(
     `schema_url` = schema_url,
@@ -131,6 +124,7 @@ model_submit <- function(data_type = NULL,
   res <- httr::POST(
     url = url,
     query = params,
+    httr::add_headers(Authorization = sprintf("Bearer %s", access_token)),
     body = files
   )
 
@@ -179,20 +173,20 @@ storage_project_datasets <- function(asset_view,
   # create url
   url <- paste0(base_url, "/v1/storage/project/datasets")
 
-  # set up header w token
-  headers <- c(
-    `access_token` = access_token
-  )
-
   # set up parameters for httr::get call
   params <- list(
     asset_view = asset_view,
-    project_id = project_id,
-    access_token = access_token
+    project_id = project_id
   )
 
   # GET
-  res <- httr::GET(url, query = params)
+  res <- httr::GET(url,
+    httr::add_headers(Authorization = sprintf(
+      "Bearer %s",
+      access_token
+    )),
+    query = params
+  )
 
   # pull out content from request
   parsed <- suppressMessages(
@@ -245,19 +239,19 @@ storage_projects <- function(asset_view,
   # create url
   url <- paste0(base_url, "/v1/storage/projects")
 
-  # set up header w token
-  headers <- c(
-    `access_token` = access_token
-  )
-
   # set up parameters for httr::get call
   params <- list(
-    asset_view = asset_view,
-    access_token = access_token
+    asset_view = asset_view
   )
 
   # GET
-  res <- httr::GET(url, query = params)
+  res <- httr::GET(url,
+    httr::add_headers(Authorization = sprintf(
+      "Bearer %s",
+      access_token
+    )),
+    query = params
+  )
 
   # pull out content from request
   parsed <- suppressMessages(
@@ -312,20 +306,21 @@ storage_project_manifests <- function(asset_view,
   # write URL
   url <- paste0(base_url, "/v1/storage/project/manifests")
 
-  # set up header w token
-  headers <- c(
-    `access_token` = access_token
-  )
-
   # set up parameters for httr::get call
   params <- list(
-    `access_token` = access_token,
     `project_id` = project_id,
     `asset_view` = asset_view
   )
 
   # GET
-  res <- httr::GET(url = url, query = params)
+  res <- httr::GET(
+    url = url,
+    httr::add_headers(Authorization = sprintf(
+      "Bearer %s",
+      access_token
+    )),
+    query = params
+  )
 
   # pull out content from request
   parsed <- suppressMessages(

--- a/R/schematic_rest_api.R
+++ b/R/schematic_rest_api.R
@@ -32,6 +32,7 @@ dataset_manifest_download <- function(asset_view,
 
   # set up parameters for httr::get call
   params <- list(
+    `access_token` = access_token,
     `asset_view` = asset_view,
     `dataset_id` = dataset_id,
     `as_json` = TRUE,
@@ -39,11 +40,7 @@ dataset_manifest_download <- function(asset_view,
   )
 
   # run GET
-  res <- httr::GET(
-    url = url,
-    httr::add_headers(Authorization = sprintf("Bearer %s", access_token)),
-    query = params
-  )
+  res <- httr::GET(url = url, query = params)
 
   # pull out content from request
   parsed <- suppressMessages(
@@ -122,6 +119,7 @@ model_submit <- function(data_type = NULL,
     `manifest_record_type` = manifest_record_type,
     `restrict_rules` = restrict_rules,
     `asset_view` = asset_view,
+    `access_token` = access_token,
     `use_schema_label` = use_schema_label
   )
 
@@ -132,7 +130,6 @@ model_submit <- function(data_type = NULL,
   # POST
   res <- httr::POST(
     url = url,
-    httr::add_headers(Authorization = sprintf("Bearer %s", access_token)),
     query = params,
     body = files
   )
@@ -189,16 +186,13 @@ storage_project_datasets <- function(asset_view,
 
   # set up parameters for httr::get call
   params <- list(
-    `asset_view` = asset_view,
-    `project_id` = project_id
+    asset_view = asset_view,
+    project_id = project_id,
+    access_token = access_token
   )
 
   # GET
-  res <- httr::GET(
-    url = url,
-    httr::add_headers(Authorization = sprintf("Bearer %s", access_token)),
-    query = params
-  )
+  res <- httr::GET(url, query = params)
 
   # pull out content from request
   parsed <- suppressMessages(
@@ -258,15 +252,12 @@ storage_projects <- function(asset_view,
 
   # set up parameters for httr::get call
   params <- list(
-    asset_view = asset_view
+    asset_view = asset_view,
+    access_token = access_token
   )
 
   # GET
-  res <- httr::GET(
-    url = url,
-    httr::add_headers(Authorization = sprintf("Bearer %s", access_token)),
-    query = params
-  )
+  res <- httr::GET(url, query = params)
 
   # pull out content from request
   parsed <- suppressMessages(
@@ -328,16 +319,13 @@ storage_project_manifests <- function(asset_view,
 
   # set up parameters for httr::get call
   params <- list(
+    `access_token` = access_token,
     `project_id` = project_id,
     `asset_view` = asset_view
   )
 
   # GET
-  res <- httr::GET(
-    url = url,
-    httr::add_headers(Authorization = sprintf("Bearer %s", access_token)),
-    query = params
-  )
+  res <- httr::GET(url = url, query = params)
 
   # pull out content from request
   parsed <- suppressMessages(
@@ -409,6 +397,12 @@ visualize_component <- function(schema_url,
 
   # GET
   res <- httr::GET(url = url, query = params)
+
+  # check that application returns json
+  # even when json = TRUE, http_type = "text/csv"
+  # if (httr::http_type(res) != "application/json") {
+  #   stop("API did not return json", call. = FALSE)
+  # }
 
   # pull out content from request
   parsed <- suppressMessages(httr::content(res))

--- a/R/schematic_rest_api.R
+++ b/R/schematic_rest_api.R
@@ -2,12 +2,14 @@
 ## Schematic API Functions ##
 #############################
 
-# Functions follow best practice convention laid out in httr vingette
+# Functions follow best practice convention laid out in httr vignette
 # https://httr.r-lib.org/articles/api-packages.html
 
 #' Download a manifest using the dataset Synapse ID
 #'
-#' @param asset_view ID of view listing all project data assets. For example, for Synapse this would be the Synapse ID of the fileview listing all data assets for a given project.(i.e. master_fileview in config.yml)
+#' @param asset_view ID of view listing all project data assets. For example,
+#' for Synapse this would be the Synapse ID of the fileview listing all data
+#' assets for a given project.(i.e. master_fileview in config.yml)
 #' @param dataset_id Synapse ID of existing manifest
 #' @param access_token Synapse login cookie, PAT, or API key.
 #' @param base_url URL to schematic API endpoint
@@ -16,13 +18,15 @@
 dataset_manifest_download <- function(asset_view,
                                       dataset_id,
                                       access_token,
-                                      base_url = "https://schematic-dev.api.sagebionetworks.org") {
-
+                                      base_url = paste0(
+                                        "https://",
+                                        "schematic.api.sagebionetworks.org"
+                                      )) {
   # create api url
   url <- paste0(base_url, "/v1/dataset/manifest/download")
 
   # set up parameters for httr::get call
-  params = list(
+  params <- list(
     `access_token` = access_token,
     `asset_view` = asset_view,
     `dataset_id` = dataset_id,
@@ -33,14 +37,10 @@ dataset_manifest_download <- function(asset_view,
   # run GET
   res <- httr::GET(url = url, query = params)
 
-  # check that application returns json
-  # even when json = TRUE, http_type = "text/csv"
-  # if (httr::http_type(res) != "application/json") {
-  #   stop("API did not return json", call. = FALSE)
-  # }
-
   # pull out content from request
-  parsed <- suppressMessages(jsonlite::fromJSON(httr::content(res, as = "text")))
+  parsed <- suppressMessages(
+    jsonlite::fromJSON(httr::content(res, as = "text"))
+  )
 
   # if the api call returns an error
   # surface error to user
@@ -68,12 +68,17 @@ dataset_manifest_download <- function(asset_view,
 #' schematic rest api to submit metadata
 #'
 #' @param data_type Type of dataset. Set to None for no validation check
-#' @param asset_view ID of view listing all project data assets. For example, for Synapse this would be the Synapse ID of the fileview listing all data assets for a given project.(i.e. master_fileview in config.yml)
+#' @param asset_view ID of view listing all project data assets. For example,
+#' for Synapse this would be the Synapse ID of the fileview listing all data
+#' assets for a given project.(i.e. master_fileview in config.yml)
 #' @param dataset_id Synapse ID of existing manifest
 #' @param file_name Filepath of csv to validate
 #' @param access_token Synapse login cookie, PAT, or API key
-#' @param restrict_rules If True, validation suite will only run with in-house validation rule. If False, the Great Expectations suite will be utilized and all rules will be available.
-#' @param manifest_record_type Manifest storage type. Options: "--", "table" (default), "entity", "both".
+#' @param restrict_rules If True, validation suite will only run with in-house
+#' validation rule. If False, the Great Expectations suite will be utilized and
+#' all rules will be available.
+#' @param manifest_record_type Manifest storage type. Options: "--", "table"
+#' (default), "entity", "both".
 #' @param base_url URL to schematic API endpoint
 #' @param schema_url URL to a schema jsonld
 #'
@@ -87,15 +92,17 @@ model_submit <- function(data_type = NULL,
                          access_token,
                          restrict_rules = TRUE,
                          manifest_record_type = "file_only",
-                         base_url = "https://schematic-dev.api.sagebionetworks.org",
-                         schema_url="https://raw.githubusercontent.com/Sage-Bionetworks/data_flow/main/inst/data_flow_component.jsonld",
+                         base_url = paste0(
+                           "https://",
+                           "schematic.api.sagebionetworks.org"
+                         ),
+                         schema_url,
                          use_schema_label = TRUE) {
-
   # create url
   url <- paste0(base_url, "/v1/model/submit")
 
   # set up parameters for httr::get call
-  params = list(
+  params <- list(
     `schema_url` = schema_url,
     `data_type` = data_type,
     `dataset_id` = dataset_id,
@@ -106,14 +113,16 @@ model_submit <- function(data_type = NULL,
     `use_schema_label` = use_schema_label
   )
 
-  files = list(
+  files <- list(
     `file_name` = httr::upload_file(file_name)
   )
 
   # POST
-  res <- httr::POST(url = url,
-                    query = params,
-                    body = files)
+  res <- httr::POST(
+    url = url,
+    query = params,
+    body = files
+  )
 
   # parse response for content
   parsed <- httr::content(res)
@@ -140,20 +149,23 @@ model_submit <- function(data_type = NULL,
   )
 }
 
-#' Gets all datasets in folder under a given storage project that the current user has access to.
+#' Gets all datasets in a given storage project
 #'
 #' @param asset_view synapse ID of master file view.
 #' @param project_id synapse ID of a storage project.
 #' @param access_token synapse PAT
 #' @param base_url URL to schematic API endpoint
 #'
-#'@export
+#' @export
 
 storage_project_datasets <- function(asset_view,
                                      project_id,
                                      access_token,
-                                     base_url = "https://schematic-dev.api.sagebionetworks.org") {
-
+                                     base_url = paste0(
+                                       "https://",
+                                       "schematic.api.",
+                                       "sagebionetworks.org"
+                                     )) {
   # create url
   url <- paste0(base_url, "/v1/storage/project/datasets")
 
@@ -161,13 +173,16 @@ storage_project_datasets <- function(asset_view,
   params <- list(
     asset_view = asset_view,
     project_id = project_id,
-    access_token = access_token)
+    access_token = access_token
+  )
 
   # GET
   res <- httr::GET(url, query = params)
 
   # pull out content from request
-  parsed <- suppressMessages(jsonlite::fromJSON(httr::content(res, as = "text")))
+  parsed <- suppressMessages(
+    jsonlite::fromJSON(httr::content(res, as = "text"))
+  )
 
   # if the api call returns an error
   # surface error to user
@@ -184,9 +199,9 @@ storage_project_datasets <- function(asset_view,
 
 
   # return parsed matrix as dataframe
-  parsed_df <-data.frame(parsed)
+  parsed_df <- data.frame(parsed)
 
-  if ( nrow(parsed_df > 0) ) {
+  if (nrow(parsed_df > 0)) {
     names(parsed_df) <- c("id", "name")
   }
 
@@ -210,8 +225,8 @@ storage_project_datasets <- function(asset_view,
 
 storage_projects <- function(asset_view,
                              access_token,
-                             base_url = "https://schematic-dev.api.sagebionetworks.org") {
-
+                             base_url =
+                               "https://schematic.api.sagebionetworks.org") {
   # create url
   url <- paste0(base_url, "/v1/storage/projects")
 
@@ -225,7 +240,9 @@ storage_projects <- function(asset_view,
   res <- httr::GET(url, query = params)
 
   # pull out content from request
-  parsed <- suppressMessages(jsonlite::fromJSON(httr::content(res, as = "text")))
+  parsed <- suppressMessages(
+    jsonlite::fromJSON(httr::content(res, as = "text"))
+  )
 
   # if the api call returns an error
   # surface error to user
@@ -266,23 +283,29 @@ storage_projects <- function(asset_view,
 storage_project_manifests <- function(asset_view,
                                       project_id,
                                       access_token,
-                                      base_url = "https://schematic-dev.api.sagebionetworks.org") {
-
+                                      base_url =
+                                        paste0(
+                                          "https://",
+                                          "schematic.api.",
+                                          "sagebionetworks.org"
+                                        )) {
   # write URL
   url <- paste0(base_url, "/v1/storage/project/manifests")
 
   # set up parameters for httr::get call
-  params = list(
+  params <- list(
     `access_token` = access_token,
     `project_id` = project_id,
     `asset_view` = asset_view
   )
 
-  #GET
+  # GET
   res <- httr::GET(url = url, query = params)
 
   # pull out content from request
-  parsed <- suppressMessages(jsonlite::fromJSON(httr::content(res, as = "text")))
+  parsed <- suppressMessages(
+    jsonlite::fromJSON(httr::content(res, as = "text"))
+  )
 
   # if the api call returns an error
   # surface error to user
@@ -302,9 +325,16 @@ storage_project_manifests <- function(asset_view,
 
   # if dataframe has content, name columns
   if (nrow(parsed_df) > 0) {
-    names(parsed_df) <- c("dataset_id", "manifest_id", "data_type", "folder_name", "file_name")
+    names(parsed_df) <- c(
+      "dataset_id",
+      "manifest_id",
+      "data_type",
+      "folder_name",
+      "file_name"
+    )
+
     # drop redundant data type column
-    parsed_df <- parsed_df[,-6]
+    parsed_df <- parsed_df[, -6]
   }
 
   # return a helpful object
@@ -318,7 +348,8 @@ storage_project_manifests <- function(asset_view,
 }
 
 
-#' Get all the attributes associated with a specific data model component formatted as a dataframe
+#' Get all the attributes associated with a specific data model component
+#' formatted as a dataframe
 #'
 #' @param schema_url A data model URL
 #' @param component Component of the data model to explore
@@ -327,13 +358,13 @@ storage_project_manifests <- function(asset_view,
 
 visualize_component <- function(schema_url,
                                 component = "DataFlow",
-                                base_url = "https://schematic-dev.api.sagebionetworks.org") {
-
+                                base_url =
+                                  "https://schematic.api.sagebionetworks.org") {
   # create api url
   url <- paste0(base_url, "/v1/visualize/component")
 
   # set up parameters for httr::get
-  params = list(
+  params <- list(
     `schema_url` = schema_url,
     `component` = component,
     `include_index` = "false"
@@ -373,7 +404,8 @@ visualize_component <- function(schema_url,
   )
 }
 
-#' Get all the attributes associated with a specific data model component formatted as a dataframe
+#' Get all the attributes associated with a specific data model component
+#' formatted as a dataframe
 #'
 #' @param schema_url A data model URL
 #' @param node_display_name Display lable of node
@@ -383,12 +415,11 @@ visualize_component <- function(schema_url,
 schemas_get_node_validation_rules <- function(schema_url,
                                               node_display_name,
                                               base_url) {
-
   # api url
   url <- paste0(base_url, "/v1/schemas/get_node_validation_rules")
 
   # query parameters
-  params = list(
+  params <- list(
     `schema_url` = schema_url,
     `node_display_name` = node_display_name
   )
@@ -432,54 +463,3 @@ print.schematic_api <- function(x, ...) {
   utils::str(x$content)
   invisible(x)
 }
-
-## ARCHIVE  ####################################################################
-#
-# THIS FUNCTION IS UNTESTED AND NOT USED ANYMORE
-#
-# storage_dataset_files <- function(asset_view,
-#                                   dataset_id,
-#                                   access_token,
-#                                   file_names=list(),
-#                                   full_path=FALSE,
-#                                   base_url = "https://schematic-dev.api.sagebionetworks.org") {
-#
-#   # create url
-#   url <- paste0(base_url, "/v1/storage/dataset/files")
-#
-#   # set up parameters for httr::get call
-#   params <- list(
-#     asset_view = asset_view,
-#     dataset_id = dataset_id,
-#     file_names = file_names,
-#     full_path = full_path,
-#     access_token = access_token)
-#
-#   # GET
-#   res <- httr::GET(url, query = params)
-#
-#   # pull out content from request
-#   parsed <- jsonlite::fromJSON(httr::content(res, as = "text"))
-#
-#   # if the api call returns an error
-#   # surface error to user
-#   if (httr::http_error(res)) {
-#     stop(
-#       sprintf(
-#         "Schematic API request failed [%s]\n%s",
-#         httr::status_code(res),
-#         parsed$detail
-#       ),
-#       call. = FALSE
-#     )
-#   }
-#
-#   # return a helpful object
-#   structure(
-#     list(
-#       content = parsed,
-#       response = res
-#     ),
-#     class = "schematic_api"
-#   )
-# }

--- a/R/schematic_rest_api.R
+++ b/R/schematic_rest_api.R
@@ -393,12 +393,6 @@ visualize_component <- function(schema_url,
   # GET
   res <- httr::GET(url = url, query = params)
 
-  # check that application returns json
-  # even when json = TRUE, http_type = "text/csv"
-  # if (httr::http_type(res) != "application/json") {
-  #   stop("API did not return json", call. = FALSE)
-  # }
-
   # pull out content from request
   parsed <- suppressMessages(httr::content(res))
 

--- a/R/schematic_rest_api.R
+++ b/R/schematic_rest_api.R
@@ -27,7 +27,6 @@ dataset_manifest_download <- function(asset_view,
 
   # set up parameters for httr::get call
   params <- list(
-    `access_token` = access_token,
     `asset_view` = asset_view,
     `dataset_id` = dataset_id,
     `as_json` = TRUE,
@@ -35,7 +34,11 @@ dataset_manifest_download <- function(asset_view,
   )
 
   # run GET
-  res <- httr::GET(url = url, query = params)
+  res <- httr::GET(
+    url = url,
+    httr::add_headers(Authorization = sprintf("Bearer %s", access_token)),
+    query = params
+  )
 
   # pull out content from request
   parsed <- suppressMessages(
@@ -109,7 +112,6 @@ model_submit <- function(data_type = NULL,
     `manifest_record_type` = manifest_record_type,
     `restrict_rules` = restrict_rules,
     `asset_view` = asset_view,
-    `access_token` = access_token,
     `use_schema_label` = use_schema_label
   )
 
@@ -120,6 +122,7 @@ model_submit <- function(data_type = NULL,
   # POST
   res <- httr::POST(
     url = url,
+    httr::add_headers(Authorization = sprintf("Bearer %s", access_token)),
     query = params,
     body = files
   )
@@ -171,13 +174,16 @@ storage_project_datasets <- function(asset_view,
 
   # set up parameters for httr::get call
   params <- list(
-    asset_view = asset_view,
-    project_id = project_id,
-    access_token = access_token
+    `asset_view` = asset_view,
+    `project_id` = project_id
   )
 
   # GET
-  res <- httr::GET(url, query = params)
+  res <- httr::GET(
+    url = url,
+    httr::add_headers(Authorization = sprintf("Bearer %s", access_token)),
+    query = params
+  )
 
   # pull out content from request
   parsed <- suppressMessages(
@@ -232,12 +238,15 @@ storage_projects <- function(asset_view,
 
   # set up parameters for httr::get call
   params <- list(
-    asset_view = asset_view,
-    access_token = access_token
+    asset_view = asset_view
   )
 
   # GET
-  res <- httr::GET(url, query = params)
+  res <- httr::GET(
+    url = url,
+    httr::add_headers(Authorization = sprintf("Bearer %s", access_token)),
+    query = params
+  )
 
   # pull out content from request
   parsed <- suppressMessages(
@@ -294,13 +303,16 @@ storage_project_manifests <- function(asset_view,
 
   # set up parameters for httr::get call
   params <- list(
-    `access_token` = access_token,
     `project_id` = project_id,
     `asset_view` = asset_view
   )
 
   # GET
-  res <- httr::GET(url = url, query = params)
+  res <- httr::GET(
+    url = url,
+    httr::add_headers(Authorization = sprintf("Bearer %s", access_token)),
+    query = params
+  )
 
   # pull out content from request
   parsed <- suppressMessages(
@@ -372,12 +384,6 @@ visualize_component <- function(schema_url,
 
   # GET
   res <- httr::GET(url = url, query = params)
-
-  # check that application returns json
-  # even when json = TRUE, http_type = "text/csv"
-  # if (httr::http_type(res) != "application/json") {
-  #   stop("API did not return json", call. = FALSE)
-  # }
 
   # pull out content from request
   parsed <- suppressMessages(httr::content(res))

--- a/tests/testthat/test-schematic-api.R
+++ b/tests/testthat/test-schematic-api.R
@@ -7,74 +7,96 @@ asset_view <- "syn50896957"
 project_id <- "syn50896931"
 dataset_id <- "syn51219090"
 access_token <- Sys.getenv("SYNAPSE_PAT")
-base_url <- "https://schematic.api.sagebionetworks.org" # production rest api instance
+base_url <- Sys.getenv("DFA_SCHEMATIC_API_URL")
 testing_manifest_path <- "test_data/synapse_storage_manifest_dataflow.csv"
 schema_url <- "https://raw.githubusercontent.com/Sage-Bionetworks/data_flow/main/inst/data_model/dataflow_component.jsonld"
 
 # TEST API ##############################################################################
 
 test_that("storage_projects successfully returns a schematic_api object", {
-  sp <- try(storage_projects(asset_view = asset_view,
-                             access_token = access_token,
-                             base_url = base_url),
-            silent = FALSE)
+  sp <- try(
+    storage_projects(
+      asset_view = asset_view,
+      access_token = access_token,
+      base_url = base_url
+    ),
+    silent = FALSE
+  )
 
   expect_true(class(sp) == "schematic_api")
 })
 
 test_that("storage_project_datasets successfully returns a schematic_api object", {
-  spd <- try(storage_project_datasets(asset_view = asset_view,
-                                      project_id = project_id,
-                                      access_token = access_token,
-                                      base_url = base_url),
-             silent = FALSE)
+  spd <- try(
+    storage_project_datasets(
+      asset_view = asset_view,
+      project_id = project_id,
+      access_token = access_token,
+      base_url = base_url
+    ),
+    silent = FALSE
+  )
 
   expect_true(class(spd) == "schematic_api")
 })
 
 test_that("manifest_download successfully returns a schematic_api object", {
-  md <- try(dataset_manifest_download(access_token = access_token,
-                              asset_view = asset_view,
-                              dataset_id = dataset_id,
-                              base_url = base_url),
-            silent = FALSE)
+  md <- try(
+    dataset_manifest_download(
+      access_token = access_token,
+      asset_view = asset_view,
+      dataset_id = dataset_id,
+      base_url = base_url
+    ),
+    silent = FALSE
+  )
 
   expect_true(class(md) == "schematic_api")
-
 })
 
 test_that("model_submit successfully returns a schematic_api object", {
-  s <- try(model_submit(data_type = NULL,
-                        asset_view = asset_view,
-                        dataset_id = dataset_id,
-                        file_name = testing_manifest_path,
-                        access_token = access_token,
-                        restrict_rules = TRUE,
-                        manifest_record_type = "table_and_file",
-                        base_url = base_url,
-                        schema_url = schema_url,
-                        use_schema_label = TRUE),
-           silent = FALSE)
+  s <- try(
+    model_submit(
+      data_type = NULL,
+      asset_view = asset_view,
+      dataset_id = dataset_id,
+      file_name = testing_manifest_path,
+      access_token = access_token,
+      restrict_rules = TRUE,
+      manifest_record_type = "table_and_file",
+      base_url = base_url,
+      schema_url = schema_url,
+      use_schema_label = TRUE
+    ),
+    silent = FALSE
+  )
 
   expect_true(class(s) == "schematic_api")
 })
 
 test_that("storage_project_manifests successfully returns a schematic_api object", {
-  spm <- try(storage_project_manifests(asset_view,
-                                      project_id,
-                                      access_token,
-                                      base_url),
-            silent = FALSE)
+  spm <- try(
+    storage_project_manifests(
+      asset_view,
+      project_id,
+      access_token,
+      base_url
+    ),
+    silent = FALSE
+  )
 
   expect_true(class(spm) == "schematic_api")
-
 })
 
 test_that("schemas_get_node_validation_rules returns a schematic_api object", {
-  spm <- try(schemas_get_node_validation_rules(schema_url = schema_url,
-                                               node_display_name = "Contributor",
-                                               base_url),
-             silent = FALSE)
+  spm <- try(
+    schemas_get_node_validation_rules(
+      schema_url = schema_url,
+      node_display_name = "Contributor",
+      base_url
+    ),
+    silent = FALSE
+  )
 
   expect_true(class(spm) == "schematic_api")
 })


### PR DESCRIPTION
Run tests using schematic api based on branch name. Previously had been running all tests using prod schematic api.

This way tests won't break when schematic api is updated but changes haven't been pushed up to production.