### PR TITLE
Test study status

### DIFF
--- a/R/manifest.R
+++ b/R/manifest.R
@@ -135,7 +135,7 @@ generate_dataflow_manifest <- function(asset_view,
     asset_view = asset_view,
     na_replace = na_replace,
     access_token = access_token,
-    base_url = base_url,
+    base_url = "https://schematic.api.sagebionetworks.org", # FIXME: only for testing while endpoints are down (3/18/2024)
     verbose = verbose
   )
 
@@ -159,6 +159,7 @@ generate_dataflow_manifest <- function(asset_view,
     dataflow_manifest_chunk = dataflow_manifest_chunk,
     schema_url = schema_url,
     na_replace = na_replace,
+    access_token = access_token,
     base_url = base_url
   )
 

--- a/R/manifest.R
+++ b/R/manifest.R
@@ -135,7 +135,7 @@ generate_dataflow_manifest <- function(asset_view,
     asset_view = asset_view,
     na_replace = na_replace,
     access_token = access_token,
-    base_url = "https://schematic.api.sagebionetworks.org", # FIXME: only for testing while endpoints are down (3/18/2024)
+    base_url = base_url,
     verbose = verbose
   )
 

--- a/R/synapse_rest_api.R
+++ b/R/synapse_rest_api.R
@@ -78,7 +78,7 @@ get_annotations <- function(id,
 
   # query annotations synapse endpoint
   annotations_out <- synapse_annotations(
-    id = project_id,
+    id = id,
     auth = access_token,
     url = url
   )

--- a/man/get_annotations.Rd
+++ b/man/get_annotations.Rd
@@ -7,17 +7,17 @@
 get_annotations(
   id,
   annotation_label,
-  access_token,
   na_replace = NA,
+  access_token,
   url = file.path("https://repo-prod.prod.sagebase.org", "repo/v1/entity")
 )
 }
 \arguments{
 \item{id}{Synapse ID}
 
-\item{access_token}{Synapse authentication token}
-
 \item{na_replace}{NA replacement string}
+
+\item{access_token}{Synapse authentication token}
 
 \item{url}{Synapse API endpoint URL}
 


### PR DESCRIPTION
Had to tweak base_url parameter to test the manifest generate function due to breaking change to `visualize/component` pushed to prod and a break in the `storage/projects` endpoint on dev.

Discovered a few errors, made fixes.

Don't push URL changes to dev